### PR TITLE
refactor : dev/prod env 분리

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:debateseason_frontend_v1/core/routers/get_router_name.dart';
 import 'package:debateseason_frontend_v1/core/services/shared_preferences_service.dart';
 import 'package:debateseason_frontend_v1/features/auth/bindings/auth_binding.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -16,7 +17,11 @@ void main() async {
 
   final prefsService = SharedPreferencesService();
   await prefsService.init();
-  await dotenv.load(fileName: '.env');
+  if(kDebugMode) {
+    await dotenv.load(fileName: '.env.dev');
+  } else {
+    await dotenv.load(fileName: '.env.prod');
+  }
 
   _initUiSettings();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,8 @@ flutter:
   uses-material-design: true
 
   assets:
-    - .env
+    - .env.dev
+    - .env.prod
     - assets/fonts/
     - assets/icons/
     - assets/images/


### PR DESCRIPTION
## Related issue 🛠

- closed #85 

## Work Description ✏️

-  env 2개로 분리
  -  prodenv, devenv 분리 baseUrl 다르게 적용

## Screenshot 📸

<img src="" width="360"/>

## Uncompleted Tasks 😅

- [ ] 추후 Flavoer 적용시 하나로 사용할 수 있을지 않을까? 생각됩니다.

## To Reviewers 📢
