### PR TITLE
fix : 채팅방 앱바 타이틀 정렬이 iOS와 android가 다른 현상

### DIFF
--- a/lib/features/chat/presentation/views/chat_room_screen.dart
+++ b/lib/features/chat/presentation/views/chat_room_screen.dart
@@ -40,6 +40,7 @@ class ChatRoomScreen extends GetView<ChatRoomViewModel> {
           overflow: TextOverflow.ellipsis,
         );
       }),
+      isCenter: false,
       bottom: PreferredSize(
         preferredSize: Size.fromHeight(1.0),
         child: Container(

--- a/lib/widgets/de_app_bar.dart
+++ b/lib/widgets/de_app_bar.dart
@@ -19,7 +19,7 @@ class DeAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.title,
     this.isBack = true,
     this.actions,
-    this.isCenter,
+    this.isCenter = false,
     this.backgroundColor,
     this.bottom,
   });


### PR DESCRIPTION
## Related issue 🛠

- closed #98 

## Work Description ✏️

- 채팅방 앱바 타이틀이 플랫폼(iOS, android)마다 다른 원인 찾고 수정
  - 원인 : Flutter의 AppBar는 플랫폼에 따라 자동으로 스타일을 조정하기 때문에 iOS에서는 title이 중앙 정렬, 안드로이드에서는 좌측 정렬됨
  - 해결1 : 채팅방 앱바에서 isCenter 값 false로 지정 (첫번째커밋 bd3e4091c0a3da2d6137c7647b33339c5973ce79)
  - 해결2 : 재사용위젯 DeAppBar에서 isCenter 의 default값을 false로 지정 (두번째커밋 e1a08d49a6133c708985b427b8dbbcadc9042bc6)

## Screenshot 📸

<img src="https://github.com/user-attachments/assets/187f6873-2528-4deb-ade2-99e873be8dd1" width="360"/> <img src="https://github.com/user-attachments/assets/497128b5-4477-4365-a4c3-0cd430e9601f" width="360"/>

## Uncompleted Tasks 😅

- [ ] 

## To Reviewers 📢
- **해결1번으로 할거면 모든 앱바에서 isCenter값을 필수로 초기화하게끔 required를 붙이는게 좋을 것 같고, 해결2번으로 할거면 isCenter 디폴트값을 false로 두고, 중앙정렬이 필요할 때만 isCenter에 true를 넣는 식으로 가면 됩니다. 어떤게 좋을까요?**
- (저는 몰랐는데 프로필 화면도 원래 좌측정렬이었군요..ㅋㅋ 아이폰에선 계속 중앙정렬이 되어있었습니다. 원래 그게 맞는 줄 알았네요.)
