### PR TITLE
Feat: 채팅 신고 기능 추가

### DIFF
--- a/lib/core/routers/get_router.dart
+++ b/lib/core/routers/get_router.dart
@@ -5,6 +5,7 @@ import 'package:debateseason_frontend_v1/features/chat/bindings/chat_binding.dar
 import 'package:debateseason_frontend_v1/features/chat/bindings/debate_binding.dart';
 import 'package:debateseason_frontend_v1/features/chat/presentation/views/chat_room_screen.dart';
 import 'package:debateseason_frontend_v1/features/chat/presentation/views/debate_room_screen.dart';
+import 'package:debateseason_frontend_v1/features/chat/presentation/views/inappropriate_chat_report_screen.dart';
 import 'package:debateseason_frontend_v1/features/issue/bindings/issue_binding.dart';
 import 'package:debateseason_frontend_v1/features/issue/presentation/views/issue_room_screen.dart';
 import 'package:debateseason_frontend_v1/features/issuemap/bindings/issuemap_binding.dart';
@@ -60,6 +61,11 @@ class GetRouter {
       name: GetRouterName.chat,
       page: () => ChatRoomScreen(),
       binding: ChatBinding(),
+    ),
+    GetPage(
+      name: GetRouterName.reportMessage,
+      page: () => InappropriateChatReportScreen(),
+      binding: null,
     ),
     GetPage(
       name: GetRouterName.profile,

--- a/lib/core/routers/get_router_name.dart
+++ b/lib/core/routers/get_router_name.dart
@@ -8,6 +8,7 @@ class GetRouterName {
   static const String issue = '/issue';
   static const String category = '/category';
   static const String debate = '/debate';
+  static const String reportMessage = '/report_message';
 
   /// Profile
   static const String profile = '/profile';

--- a/lib/features/chat/bindings/chat_binding.dart
+++ b/lib/features/chat/bindings/chat_binding.dart
@@ -16,6 +16,11 @@ class ChatBinding extends Bindings {
         Get.find<ChatRoomsMessagesDataSource>(),
       ),
     );
+    Get.lazyPut<ChatRoomsMessagesRepositoryImpl>(
+      () => ChatRoomsMessagesRepositoryImpl(
+        Get.find<ChatRoomsMessagesDataSource>(),
+      ),
+    );
 
     Get.lazyPut(() => ChatRoomViewModel());
   }

--- a/lib/features/chat/data/data_sources/chat_rooms_messages_data_source.dart
+++ b/lib/features/chat/data/data_sources/chat_rooms_messages_data_source.dart
@@ -1,3 +1,4 @@
+import 'package:debateseason_frontend_v1/features/chat/data/models/report_reason_req.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/entities/chat_message_entity.dart';
 import 'package:debateseason_frontend_v1/utils/base/base_res.dart';
 import 'package:dio/dio.dart';
@@ -14,6 +15,12 @@ abstract class ChatRoomsMessagesDataSource {
   Future<BaseRes<ChatRoomsMessagesRes>> getChatRoomsMessages({
     @Path('roomId') required int roomId,
     @Query('cursor') int? cursor,
+  });
+
+  @POST('/api/v1/chat/messages/{messageId}/report')
+  Future<BaseRes> reportMessage({
+    @Path() required int messageId,
+    @Body() required ReportReasonReq body,
   });
 }
 

--- a/lib/features/chat/data/data_sources/chat_rooms_messages_data_source.g.dart
+++ b/lib/features/chat/data/data_sources/chat_rooms_messages_data_source.g.dart
@@ -75,6 +75,40 @@ class _ChatRoomsMessagesDataSource implements ChatRoomsMessagesDataSource {
     return _value;
   }
 
+  @override
+  Future<BaseRes<dynamic>> reportMessage({
+    required int messageId,
+    required ReportReasonReq body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<BaseRes<dynamic>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v1/chat/messages/${messageId}/report',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseRes<dynamic> _value;
+    try {
+      _value = BaseRes<dynamic>.fromJson(
+        _result.data!,
+        (json) => json as dynamic,
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/chat/data/models/report_reason_req.dart
+++ b/lib/features/chat/data/models/report_reason_req.dart
@@ -1,0 +1,14 @@
+class ReportReasonReq {
+  final List<String> reasons;
+  final String? etcDescription;
+
+  ReportReasonReq({
+    required this.reasons,
+    this.etcDescription,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'reasonType': reasons,
+        if (etcDescription != null) 'reasonDetail': etcDescription,
+      };
+}

--- a/lib/features/chat/data/repository_impls/chat_rooms_messages_repository_impl.dart
+++ b/lib/features/chat/data/repository_impls/chat_rooms_messages_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:debateseason_frontend_v1/core/model/cursor_pagination_model.dart
 import 'package:debateseason_frontend_v1/features/chat/data/data_sources/chat_rooms_messages_data_source.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/entities/chat_message_entity.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/repositories/chat_rooms_messages_repository.dart';
+import 'package:debateseason_frontend_v1/features/chat/presentation/models/report_reason_selection.dart';
 import 'package:debateseason_frontend_v1/utils/base/base_res.dart';
 import 'package:debateseason_frontend_v1/utils/base/ui_state.dart';
 
@@ -33,6 +34,22 @@ class ChatRoomsMessagesRepositoryImpl implements ChatRoomsMessagesRepository {
       ),
     );
 
+    // handle response
+    switch (response.status) {
+      case 200:
+        return UiState.success(response.data);
+      default:
+        return UiState.failure(
+            response.message.isEmpty ? "서버 통신에 문제가 발생했습니다" : response.message);
+    }
+  }
+
+  Future<UiState> reportMessage({
+    required int messageId,
+    required ReportReasonSelection reasons,
+  }) async {
+    final response = await dataSource.reportMessage(
+        messageId: messageId, body: reasons.toReq());
     // handle response
     switch (response.status) {
       case 200:

--- a/lib/features/chat/presentation/models/report_reason_selection.dart
+++ b/lib/features/chat/presentation/models/report_reason_selection.dart
@@ -1,0 +1,47 @@
+import 'package:debateseason_frontend_v1/features/chat/data/models/report_reason_req.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'report_reason_selection.freezed.dart';
+
+@freezed
+class ReportReasonSelection with _$ReportReasonSelection {
+  const factory ReportReasonSelection({
+    @Default(false) bool isAbusive, // 욕설
+    @Default(false) bool isSexual, // 음란
+    @Default(false) bool isFalseInfo, // 허위
+    @Default(false) bool isSpam, // 도배
+    @Default(false) bool isPromotion, // 홍보
+    @Default(false) bool isPrivacyLeak, // 개인정보 노출
+    @Default(false) bool isEtc, // 기타
+    @Default("") String? etcDescription, // 기타 설명 (기타가 true일 경우 유효)
+  }) = _ReportReasonSelection;
+  const ReportReasonSelection._(); // for custom methods
+
+  /// 변환 함수 (to DTO)
+  ReportReasonReq toReq() {
+    final reasons = <String>[];
+    if (isAbusive) reasons.add("ABUSIVE");
+    if (isSexual) reasons.add("SEXUAL");
+    if (isFalseInfo) reasons.add("FALSE_INFO");
+    if (isSpam) reasons.add("SPAM");
+    if (isPromotion) reasons.add("PROMOTION");
+    if (isPrivacyLeak) reasons.add("PRIVACY_LEAK");
+    if (isEtc) reasons.add("ETC");
+
+    return ReportReasonReq(
+      reasons: reasons,
+      etcDescription: isEtc ? etcDescription : null,
+    );
+  }
+}
+
+extension ReportReasonSelectionExtension on ReportReasonSelection {
+  bool get hasAnySelected =>
+      isAbusive ||
+      isSexual ||
+      isFalseInfo ||
+      isSpam ||
+      isPromotion ||
+      isPrivacyLeak ||
+      isEtc;
+}

--- a/lib/features/chat/presentation/models/report_reason_selection.freezed.dart
+++ b/lib/features/chat/presentation/models/report_reason_selection.freezed.dart
@@ -1,0 +1,315 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'report_reason_selection.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ReportReasonSelection {
+  bool get isAbusive => throw _privateConstructorUsedError; // 욕설
+  bool get isSexual => throw _privateConstructorUsedError; // 음란
+  bool get isFalseInfo => throw _privateConstructorUsedError; // 허위
+  bool get isSpam => throw _privateConstructorUsedError; // 도배
+  bool get isPromotion => throw _privateConstructorUsedError; // 홍보
+  bool get isPrivacyLeak => throw _privateConstructorUsedError; // 개인정보 노출
+  bool get isEtc => throw _privateConstructorUsedError; // 기타
+  String? get etcDescription => throw _privateConstructorUsedError;
+
+  /// Create a copy of ReportReasonSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ReportReasonSelectionCopyWith<ReportReasonSelection> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReportReasonSelectionCopyWith<$Res> {
+  factory $ReportReasonSelectionCopyWith(ReportReasonSelection value,
+          $Res Function(ReportReasonSelection) then) =
+      _$ReportReasonSelectionCopyWithImpl<$Res, ReportReasonSelection>;
+  @useResult
+  $Res call(
+      {bool isAbusive,
+      bool isSexual,
+      bool isFalseInfo,
+      bool isSpam,
+      bool isPromotion,
+      bool isPrivacyLeak,
+      bool isEtc,
+      String? etcDescription});
+}
+
+/// @nodoc
+class _$ReportReasonSelectionCopyWithImpl<$Res,
+        $Val extends ReportReasonSelection>
+    implements $ReportReasonSelectionCopyWith<$Res> {
+  _$ReportReasonSelectionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ReportReasonSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isAbusive = null,
+    Object? isSexual = null,
+    Object? isFalseInfo = null,
+    Object? isSpam = null,
+    Object? isPromotion = null,
+    Object? isPrivacyLeak = null,
+    Object? isEtc = null,
+    Object? etcDescription = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isAbusive: null == isAbusive
+          ? _value.isAbusive
+          : isAbusive // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSexual: null == isSexual
+          ? _value.isSexual
+          : isSexual // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFalseInfo: null == isFalseInfo
+          ? _value.isFalseInfo
+          : isFalseInfo // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSpam: null == isSpam
+          ? _value.isSpam
+          : isSpam // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isPromotion: null == isPromotion
+          ? _value.isPromotion
+          : isPromotion // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isPrivacyLeak: null == isPrivacyLeak
+          ? _value.isPrivacyLeak
+          : isPrivacyLeak // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isEtc: null == isEtc
+          ? _value.isEtc
+          : isEtc // ignore: cast_nullable_to_non_nullable
+              as bool,
+      etcDescription: freezed == etcDescription
+          ? _value.etcDescription
+          : etcDescription // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ReportReasonSelectionImplCopyWith<$Res>
+    implements $ReportReasonSelectionCopyWith<$Res> {
+  factory _$$ReportReasonSelectionImplCopyWith(
+          _$ReportReasonSelectionImpl value,
+          $Res Function(_$ReportReasonSelectionImpl) then) =
+      __$$ReportReasonSelectionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {bool isAbusive,
+      bool isSexual,
+      bool isFalseInfo,
+      bool isSpam,
+      bool isPromotion,
+      bool isPrivacyLeak,
+      bool isEtc,
+      String? etcDescription});
+}
+
+/// @nodoc
+class __$$ReportReasonSelectionImplCopyWithImpl<$Res>
+    extends _$ReportReasonSelectionCopyWithImpl<$Res,
+        _$ReportReasonSelectionImpl>
+    implements _$$ReportReasonSelectionImplCopyWith<$Res> {
+  __$$ReportReasonSelectionImplCopyWithImpl(_$ReportReasonSelectionImpl _value,
+      $Res Function(_$ReportReasonSelectionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ReportReasonSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isAbusive = null,
+    Object? isSexual = null,
+    Object? isFalseInfo = null,
+    Object? isSpam = null,
+    Object? isPromotion = null,
+    Object? isPrivacyLeak = null,
+    Object? isEtc = null,
+    Object? etcDescription = freezed,
+  }) {
+    return _then(_$ReportReasonSelectionImpl(
+      isAbusive: null == isAbusive
+          ? _value.isAbusive
+          : isAbusive // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSexual: null == isSexual
+          ? _value.isSexual
+          : isSexual // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFalseInfo: null == isFalseInfo
+          ? _value.isFalseInfo
+          : isFalseInfo // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSpam: null == isSpam
+          ? _value.isSpam
+          : isSpam // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isPromotion: null == isPromotion
+          ? _value.isPromotion
+          : isPromotion // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isPrivacyLeak: null == isPrivacyLeak
+          ? _value.isPrivacyLeak
+          : isPrivacyLeak // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isEtc: null == isEtc
+          ? _value.isEtc
+          : isEtc // ignore: cast_nullable_to_non_nullable
+              as bool,
+      etcDescription: freezed == etcDescription
+          ? _value.etcDescription
+          : etcDescription // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReportReasonSelectionImpl extends _ReportReasonSelection {
+  const _$ReportReasonSelectionImpl(
+      {this.isAbusive = false,
+      this.isSexual = false,
+      this.isFalseInfo = false,
+      this.isSpam = false,
+      this.isPromotion = false,
+      this.isPrivacyLeak = false,
+      this.isEtc = false,
+      this.etcDescription = ""})
+      : super._();
+
+  @override
+  @JsonKey()
+  final bool isAbusive;
+// 욕설
+  @override
+  @JsonKey()
+  final bool isSexual;
+// 음란
+  @override
+  @JsonKey()
+  final bool isFalseInfo;
+// 허위
+  @override
+  @JsonKey()
+  final bool isSpam;
+// 도배
+  @override
+  @JsonKey()
+  final bool isPromotion;
+// 홍보
+  @override
+  @JsonKey()
+  final bool isPrivacyLeak;
+// 개인정보 노출
+  @override
+  @JsonKey()
+  final bool isEtc;
+// 기타
+  @override
+  @JsonKey()
+  final String? etcDescription;
+
+  @override
+  String toString() {
+    return 'ReportReasonSelection(isAbusive: $isAbusive, isSexual: $isSexual, isFalseInfo: $isFalseInfo, isSpam: $isSpam, isPromotion: $isPromotion, isPrivacyLeak: $isPrivacyLeak, isEtc: $isEtc, etcDescription: $etcDescription)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReportReasonSelectionImpl &&
+            (identical(other.isAbusive, isAbusive) ||
+                other.isAbusive == isAbusive) &&
+            (identical(other.isSexual, isSexual) ||
+                other.isSexual == isSexual) &&
+            (identical(other.isFalseInfo, isFalseInfo) ||
+                other.isFalseInfo == isFalseInfo) &&
+            (identical(other.isSpam, isSpam) || other.isSpam == isSpam) &&
+            (identical(other.isPromotion, isPromotion) ||
+                other.isPromotion == isPromotion) &&
+            (identical(other.isPrivacyLeak, isPrivacyLeak) ||
+                other.isPrivacyLeak == isPrivacyLeak) &&
+            (identical(other.isEtc, isEtc) || other.isEtc == isEtc) &&
+            (identical(other.etcDescription, etcDescription) ||
+                other.etcDescription == etcDescription));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isAbusive, isSexual, isFalseInfo,
+      isSpam, isPromotion, isPrivacyLeak, isEtc, etcDescription);
+
+  /// Create a copy of ReportReasonSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReportReasonSelectionImplCopyWith<_$ReportReasonSelectionImpl>
+      get copyWith => __$$ReportReasonSelectionImplCopyWithImpl<
+          _$ReportReasonSelectionImpl>(this, _$identity);
+}
+
+abstract class _ReportReasonSelection extends ReportReasonSelection {
+  const factory _ReportReasonSelection(
+      {final bool isAbusive,
+      final bool isSexual,
+      final bool isFalseInfo,
+      final bool isSpam,
+      final bool isPromotion,
+      final bool isPrivacyLeak,
+      final bool isEtc,
+      final String? etcDescription}) = _$ReportReasonSelectionImpl;
+  const _ReportReasonSelection._() : super._();
+
+  @override
+  bool get isAbusive; // 욕설
+  @override
+  bool get isSexual; // 음란
+  @override
+  bool get isFalseInfo; // 허위
+  @override
+  bool get isSpam; // 도배
+  @override
+  bool get isPromotion; // 홍보
+  @override
+  bool get isPrivacyLeak; // 개인정보 노출
+  @override
+  bool get isEtc; // 기타
+  @override
+  String? get etcDescription;
+
+  /// Create a copy of ReportReasonSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReportReasonSelectionImplCopyWith<_$ReportReasonSelectionImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/features/chat/presentation/view_models/chat_room_view_model.dart
+++ b/lib/features/chat/presentation/view_models/chat_room_view_model.dart
@@ -3,6 +3,7 @@ import 'package:debateseason_frontend_v1/core/routers/get_router_name.dart';
 import 'package:debateseason_frontend_v1/core/services/shared_preferences_service.dart';
 import 'package:debateseason_frontend_v1/core/services/web_socket/stomp_service.dart';
 import 'package:debateseason_frontend_v1/features/chat/data/models/room_res.dart';
+import 'package:debateseason_frontend_v1/features/chat/data/repository_impls/chat_rooms_messages_repository_impl.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/entities/chat_message_entity.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/enums/chat_message_type.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/repositories/chat_rooms_messages_repository.dart';
@@ -86,6 +87,19 @@ class ChatRoomViewModel extends GetxController {
       GetRouterName.reportMessage,
     );
 
+    // 뒤로가기 했을 경우에는 생략.
+    if (data == null) return null;
+
+    final repo = Get.find<ChatRoomsMessagesRepositoryImpl>();
+    final status =
+        await repo.reportMessage(messageId: messageId, reasons: data);
+    // message 신고 후, 서버로부터의 응답여부에 따라 토스트 여부 결정
+
+    return status.when(
+      loading: () => "서버에 문제가 있습니다.",
+      success: (data) => data,
+      failure: (data) => data,
+    );
   }
 
   void sendMessage(String content) {

--- a/lib/features/chat/presentation/view_models/chat_room_view_model.dart
+++ b/lib/features/chat/presentation/view_models/chat_room_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:debateseason_frontend_v1/core/model/cursor_pagination_model.dart';
+import 'package:debateseason_frontend_v1/core/routers/get_router_name.dart';
 import 'package:debateseason_frontend_v1/core/services/shared_preferences_service.dart';
 import 'package:debateseason_frontend_v1/core/services/web_socket/stomp_service.dart';
 import 'package:debateseason_frontend_v1/features/chat/data/models/room_res.dart';
@@ -80,7 +81,12 @@ class ChatRoomViewModel extends GetxController {
     );
   }
 
-  void reportInappropriateChat(int index) {}
+  Future<String?> reportInappropriateChat(int messageId) async {
+    final data = await Get.toNamed(
+      GetRouterName.reportMessage,
+    );
+
+  }
 
   void sendMessage(String content) {
     try {

--- a/lib/features/chat/presentation/views/chat_room_screen.dart
+++ b/lib/features/chat/presentation/views/chat_room_screen.dart
@@ -8,6 +8,7 @@ import 'package:debateseason_frontend_v1/features/chat/presentation/view_models/
 import 'package:debateseason_frontend_v1/features/chat/presentation/widgets/chat_input_field.dart';
 import 'package:debateseason_frontend_v1/features/chat/presentation/widgets/chat_message.dart';
 import 'package:debateseason_frontend_v1/utils/date_format_util.dart';
+import 'package:debateseason_frontend_v1/utils/de_snack_bar.dart';
 import 'package:debateseason_frontend_v1/utils/logger.dart';
 import 'package:debateseason_frontend_v1/widgets/import_de.dart';
 import 'package:flutter/material.dart';
@@ -155,7 +156,11 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
                 return ChatMessage(
                   chatMessageModel,
                   parentHeight: parentHeight,
-                  onInappropriateChatReport: viewModel.reportInappropriateChat,
+                  onInappropriateChatReport: (messageId) async {
+                    final reportMessage =
+                        await viewModel.reportInappropriateChat(messageId);
+                    if (reportMessage != null) deSnackBar(reportMessage);
+                  },
                 );
               },
               separatorBuilder: (context, index) {

--- a/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
+++ b/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
@@ -1,6 +1,7 @@
 import 'package:debateseason_frontend_v1/core/constants/de_colors.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_fonts.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_gaps.dart';
+import 'package:debateseason_frontend_v1/features/chat/presentation/models/report_reason_selection.dart';
 import 'package:debateseason_frontend_v1/features/chat/presentation/widgets/custom_checkbox.dart';
 import 'package:debateseason_frontend_v1/widgets/import_de.dart';
 import 'package:flutter/material.dart';
@@ -54,7 +55,19 @@ class _InappropriateChatReportScreenState
             DeButtonLarge(
               "확인",
               onPressed: () async {
-                Get.back<List<bool>>(result: isCheckedList);
+                // 신고 항목 전달.
+                Get.back<ReportReasonSelection>(
+                    result: ReportReasonSelection(
+                        isAbusive: isCheckedList[0],
+                        isSexual: isCheckedList[1],
+                        isFalseInfo: isCheckedList[2],
+                        isSpam: isCheckedList[3],
+                        isPromotion: isCheckedList[4],
+                        isPrivacyLeak: isCheckedList[5],
+                        isEtc: isCheckedList[6],
+                        etcDescription: isCheckedList[6]
+                            ? customReasonController.text
+                            : null));
               },
               enable: isCheckedList.contains(true) ? true : false,
             ),

--- a/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
+++ b/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
@@ -34,7 +34,9 @@ class _InappropriateChatReportScreenState
         child: Column(
           children: [
             Text(
-              "허위 신고일 경우, 신고자의 서비스 활동이 제한될 수 있으니 유의해주세요.",
+              "신고 누적 시 해당 대화가 삭제되거나 작성자의 서비스 이용이 "
+              "제한됩니다. 신고는 제출 후 수정이 불가하며, 허위 신고 시 "
+              "신고자의 서비스 이용이 제한될 수 있으니 주의해 주세요.",
               style: DeFonts.body14M.copyWith(color: DeColors.grey30),
             ),
             DeGaps.v28,

--- a/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
+++ b/lib/features/chat/presentation/views/inappropriate_chat_report_screen.dart
@@ -17,6 +17,8 @@ class InappropriateChatReportScreen extends StatefulWidget {
 class _InappropriateChatReportScreenState
     extends State<InappropriateChatReportScreen> {
   List<bool> isCheckedList = List.generate(7, (index) => false); // 체크 상태 리스트
+  bool isCustomReasonVisible = false;
+  late TextEditingController customReasonController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +49,7 @@ class _InappropriateChatReportScreenState
             DeGaps.v20,
             renderCheckbox("개인 정보 노출, 유포, 거래", 5),
             DeGaps.v20,
-            renderCheckbox("기타", 6),
+            renderCheckboxWithReason("기타", 6),
             Spacer(),
             DeButtonLarge(
               "확인",
@@ -79,6 +81,43 @@ class _InappropriateChatReportScreenState
             });
           },
         ),
+      ],
+    );
+  }
+
+  Widget renderCheckboxWithReason(String text, int index) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              text,
+              style: DeFonts.body16M,
+            ),
+            CustomCheckbox(
+              isChecked: isCheckedList[index],
+              onChanged: (newValue) {
+                setState(() {
+                  isCustomReasonVisible = newValue;
+                  isCheckedList[index] = newValue;
+                });
+              },
+            ),
+          ],
+        ),
+        DeGaps.v12,
+        if (isCustomReasonVisible)
+          SizedBox(
+            height: 120,
+            child: DeTextField(
+              textAlignVertical: TextAlignVertical.top, // 글자 상단 정렬
+              controller: customReasonController,
+              isCleanIcon: false, // 삭제 버튼 없앰
+              expands: true,
+              maxLines: null,
+            ),
+          ),
       ],
     );
   }

--- a/lib/features/chat/presentation/widgets/chat_message.dart
+++ b/lib/features/chat/presentation/widgets/chat_message.dart
@@ -76,13 +76,16 @@ class _ChatMessageState extends State<ChatMessage> {
               left: left,
               child: Material(
                 color: Colors.transparent,
-                child: ReactionPicker(
-                  onReactionSelect: (emoji) {
-                    Navigator.pop(context);
-                  },
-                  onInappropriateChatReport: () => widget
-                      .onInappropriateChatReport(widget.chatMessageEntity.id),
-                ),
+                child: ReactionPicker(onReactionSelect: (emoji) {
+                  Navigator.pop(context);
+                }, onInappropriateChatReport: () {
+                  Navigator.pop(context);
+                  Future.microtask(() {
+                    // 팝업창 닫히는 것 보장.
+                    widget
+                        .onInappropriateChatReport(widget.chatMessageEntity.id);
+                  });
+                }),
               ),
             ),
           ],

--- a/lib/features/chat/presentation/widgets/chat_message.dart
+++ b/lib/features/chat/presentation/widgets/chat_message.dart
@@ -6,6 +6,7 @@ import 'package:debateseason_frontend_v1/core/constants/de_fonts.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_gaps.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_icons.dart';
 import 'package:debateseason_frontend_v1/features/chat/domain/entities/chat_message_entity.dart';
+import 'package:debateseason_frontend_v1/features/chat/presentation/widgets/reaction_picker.dart';
 import 'package:debateseason_frontend_v1/widgets/de_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
@@ -27,63 +28,68 @@ class ChatMessage extends StatefulWidget {
 }
 
 class _ChatMessageState extends State<ChatMessage> {
-  // void _showReactionModal(
-  //   BuildContext context,
-  //   GlobalKey messageKey,
-  //   Alignment aligntment,
-  //   String? link,
-  // ) {
-  //   final RenderBox renderBox =
-  //       messageKey.currentContext!.findRenderObject() as RenderBox;
-  //   final Offset position = renderBox.localToGlobal(Offset.zero);
-  //   final linkHeight = (link == null) ? 0 : 220; // 220 is Preview Size
-  //   final Size chatBubbleSize = Size(
-  //       renderBox.size.width, renderBox.size.height - linkHeight); // 메시지 크기
+  void _showReactionModal(
+    BuildContext context,
+    GlobalKey messageKey,
+    Alignment aligntment,
+    String? link,
+  ) {
+    final RenderBox renderBox = messageKey.currentContext!.findRenderObject()
+        as RenderBox; // messageKey로 지정된 위젯
+    final Offset position = renderBox
+        .localToGlobal(Offset.zero); // messageKey 로 지정된 위치가 현재 전체 화면상에서 어디인지 확인
+    final linkHeight = (link == null) ? 0 : 220; // 220 is Preview Size
+    final Size chatBubbleSize = Size(
+        renderBox.size.width, renderBox.size.height - linkHeight); // 메시지 크기
 
-  //   double pickerTop;
-  //   // bubble 하단에 이미지 픽커가 Default
-  //   // bubble 하단에서 시현해서 잘려질 경우, 위쪽에 표시
-  //   if (widget.parentHeight <
-  //       position.dy - kToolbarHeight + chatBubbleSize.height + 84) {
-  //     pickerTop = position.dy -
-  //         kToolbarHeight -
-  //         84 +
-  //         20 -
-  //         6; // 84 is reaction picker size 20 is chat header 6 is gap
-  //   } else {
-  //     pickerTop = position.dy - kToolbarHeight + chatBubbleSize.height;
-  //   }
+    double pickerTop;
+    // bubble 하단에 이미지 픽커가 Default
+    // bubble 하단에서 시현해서 잘려질 경우, 위쪽에 표시
+    double reactionPickerHeight = 40; // 픽커의 행이 2개일 때, 84(Gap 포함). 아니면 40
+    if (widget.parentHeight <
+        position.dy -
+            kToolbarHeight +
+            chatBubbleSize.height +
+            reactionPickerHeight) {
+      pickerTop = position.dy -
+          kToolbarHeight -
+          reactionPickerHeight +
+          20 -
+          6; // 84 is reaction picker size 20 is chat header 6 is gap
+    } else {
+      pickerTop = position.dy - kToolbarHeight + chatBubbleSize.height;
+    }
 
-  //   final right =
-  //       aligntment == Alignment.centerRight ? 20.0 : null; // 20 padding
-  //   final left = aligntment == Alignment.centerLeft ? 20.0 : null; // 20 padding
+    final right =
+        aligntment == Alignment.centerRight ? 20.0 : null; // 20 padding
+    final left = aligntment == Alignment.centerLeft ? 20.0 : null; // 20 padding
 
-  //   showDialog(
-  //     context: context,
-  //     barrierColor: Colors.transparent,
-  //     builder: (context) {
-  //       return Stack(
-  //         children: [
-  //           Positioned(
-  //             top: pickerTop,
-  //             right: right,
-  //             left: left,
-  //             child: Material(
-  //               color: Colors.transparent,
-  //               child: ReactionPicker(
-  //                 onReactionSelect: (emoji) {
-  //                   Navigator.pop(context);
-  //                 },
-  //                 onInappropriateChatReport: () => widget
-  //                     .onInappropriateChatReport(widget.chatMessageEntity.id),
-  //               ),
-  //             ),
-  //           ),
-  //         ],
-  //       );
-  //     },
-  //   );
-  // }
+    showDialog(
+      context: context,
+      barrierColor: Colors.transparent,
+      builder: (context) {
+        return Stack(
+          children: [
+            Positioned(
+              top: pickerTop,
+              right: right,
+              left: left,
+              child: Material(
+                color: Colors.transparent,
+                child: ReactionPicker(
+                  onReactionSelect: (emoji) {
+                    Navigator.pop(context);
+                  },
+                  onInappropriateChatReport: () => widget
+                      .onInappropriateChatReport(widget.chatMessageEntity.id),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -115,8 +121,8 @@ class _ChatMessageState extends State<ChatMessage> {
       alignment: alignment,
       child: GestureDetector(
         key: messageKey,
-        // onLongPress: () =>
-        //     _showReactionModal(context, messageKey, alignment, link),
+        onLongPress: () =>
+            _showReactionModal(context, messageKey, alignment, link),
         child: Column(
           crossAxisAlignment: crossAxisAlignment,
           children: [

--- a/lib/features/chat/presentation/widgets/reaction_picker.dart
+++ b/lib/features/chat/presentation/widgets/reaction_picker.dart
@@ -1,6 +1,5 @@
 import 'package:debateseason_frontend_v1/core/constants/de_colors.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_fonts.dart';
-import 'package:debateseason_frontend_v1/core/constants/de_gaps.dart';
 import 'package:flutter/material.dart';
 
 class ReactionPicker extends StatelessWidget {
@@ -20,47 +19,50 @@ class ReactionPicker extends StatelessWidget {
       child: Column(
         children: [
           // 리액션
-          Container(
-            padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-            decoration: BoxDecoration(
-              color: DeColors.grey70,
-              borderRadius: BorderRadius.circular(40),
-            ),
-            child: IntrinsicHeight(
-              child: Row(mainAxisSize: MainAxisSize.min, children: [
-                Image.asset(
-                  'assets/images/logic_minus.png',
-                  width: 24,
-                  height: 24,
-                ),
-                DeGaps.h12,
-                Image.asset(
-                  'assets/images/logic_plus.png',
-                  width: 24,
-                  height: 24,
-                ),
-                VerticalDivider(
-                  color: DeColors.grey50,
-                  width: 25,
-                  thickness: 1,
-                  indent: 6,
-                  endIndent: 6,
-                ),
-                Image.asset(
-                  'assets/images/attitude_minus.png',
-                  width: 24,
-                  height: 24,
-                ),
-                DeGaps.h12,
-                Image.asset(
-                  'assets/images/attitude_plus.png',
-                  width: 24,
-                  height: 24,
-                ),
-              ]),
-            ),
-          ),
-          DeGaps.v4,
+          // Container(
+          //   padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          //   decoration: BoxDecoration(
+          //     color: DeColors.grey70,
+          //     borderRadius: BorderRadius.circular(40),
+          //   ),
+          //   child: IntrinsicHeight(
+          //     child: Row(
+          //       mainAxisSize: MainAxisSize.min,
+          //       children: [
+          //         Image.asset(
+          //           'assets/images/logic_minus.png',
+          //           width: 24,
+          //           height: 24,
+          //         ),
+          //         DeGaps.h12,
+          //         Image.asset(
+          //           'assets/images/logic_plus.png',
+          //           width: 24,
+          //           height: 24,
+          //         ),
+          //         VerticalDivider(
+          //           color: DeColors.grey50,
+          //           width: 25,
+          //           thickness: 1,
+          //           indent: 6,
+          //           endIndent: 6,
+          //         ),
+          //         Image.asset(
+          //           'assets/images/attitude_minus.png',
+          //           width: 24,
+          //           height: 24,
+          //         ),
+          //         DeGaps.h12,
+          //         Image.asset(
+          //           'assets/images/attitude_plus.png',
+          //           width: 24,
+          //           height: 24,
+          //         ),
+          //       ],
+          //     ),
+          //   ),
+          // ),
+          // DeGaps.v4,
           // 신고
           Container(
             padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),

--- a/lib/widgets/de_text_field.dart
+++ b/lib/widgets/de_text_field.dart
@@ -1,7 +1,7 @@
 import 'package:debateseason_frontend_v1/core/constants/de_colors.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_dimensions.dart';
-import 'package:debateseason_frontend_v1/core/constants/de_icons.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_fonts.dart';
+import 'package:debateseason_frontend_v1/core/constants/de_icons.dart';
 import 'package:debateseason_frontend_v1/widgets/de_gesture_detector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -27,6 +27,7 @@ class DeTextField extends StatelessWidget {
   final List<TextInputFormatter>? inputFormatters;
   final bool? enabled;
   final bool isCleanIcon;
+  final TextAlignVertical? textAlignVertical;
 
   const DeTextField({
     super.key,
@@ -49,6 +50,7 @@ class DeTextField extends StatelessWidget {
     this.inputFormatters,
     this.enabled,
     this.isCleanIcon = true,
+    this.textAlignVertical,
   });
 
   @override
@@ -88,8 +90,7 @@ class DeTextField extends StatelessWidget {
                           onTap: () => controller.clear(),
                           child: Padding(
                             padding: DeDimensions.all10,
-                            child: SvgPicture.asset(
-                                DeIcons.icXGrey50),
+                            child: SvgPicture.asset(DeIcons.icXGrey50),
                           ),
                         )
                       : null)
@@ -118,6 +119,7 @@ class DeTextField extends StatelessWidget {
         },
         inputFormatters: inputFormatters,
         enabled: enabled,
+        textAlignVertical: textAlignVertical,
       ),
     );
   }


### PR DESCRIPTION
## Related issue 🛠

- closed #132

## Work Description ✏️

- 채팅방 신고 기능 추가
- 채팅 신고는 24시간 이내 검토하여, 서버에서 메시지 차단 여부 설정.
  - 검토 이전까지 신고된 메시지는 유지
  - 검토 이후에는 서버에서 필터링 된 데이터 제공

## API
### ReasonType 항목
- "ABUSIVE"
- "SEXUAL"
- "FALSE_INFO"
- "SPAM"
- "PROMOTION"
- "PRIVACY_LEAK"
- "ETC"
### Example
REQ Ex1
{
  "reasonType": ["ABUSIVE", "SEXUAL"],
  "reasonDetail": ""
}
REQ Ex2
{
  "reasonType": ["ABUSIVE", "ETC"],
  "reasonDetail": "주제와 관련 없는 대화를 하고 있습니다."
}

RES EX1
{
    "status": 200,
    "code": "SUCCESS",
    "message": "메시지가 신고되었습니다.",
    "data": {
    }
}

## Screenshot 📸

### 채팅 위치에 따른 신고 액션 다이얼로그 위치 변경. (기본 : 채팅 아래)
<p>
  <img src="https://github.com/user-attachments/assets/16deda6e-1956-4c59-8992-b4831d63535b" width="360"/>
  <img src="https://github.com/user-attachments/assets/5dac5665-f6dd-46dc-bbe7-3aac6e228540" width="360"/>
</p>

### 채팅 신고하기 페이지
사용자 입력은 기타를 누를 때만 시현. 동일 페이지 내에서 체크 선택 해제할 경우. TextField에 기존 입력한 내용유지됨.
체크 박스가 1개 이상일 경우, 확인버튼 Enable
<p>
  <img src="https://github.com/user-attachments/assets/98740ada-5539-48dc-af2b-c4b673369e89" width="360"/>
  <img src="https://github.com/user-attachments/assets/fdf7c99b-abf5-4f56-bc42-9d36653b6906" width="360"/>
  <img src="https://github.com/user-attachments/assets/844e0aef-42b0-4509-90b7-262a2dda3e9e" width="360"/>
  <img src="https://github.com/user-attachments/assets/6c608bf4-0378-40e0-920b-425a84e33cd6" width="360"/>
</p>

### 신고 후, 토스트 팝업
서버에서의 정상, 에러 응답의 메시지를 그대로 시현
정상일 경우, "메시지가 신고되었습니다."
아래는 로컬 테스트 서버로 띄운 응답 메시지 시현 
![image](https://github.com/user-attachments/assets/5b424a00-8e8b-4558-bf42-f068202457d3)

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
서버 작업자랑 합의된 요구사항은 안됨. 연락 X
자체 서버 띄워서 자체 테스트만 함.