### PR TITLE
fix : 4차 스프린트 UI 수정

### DIFF
--- a/lib/features/home/presentation/views/home_screen.dart
+++ b/lib/features/home/presentation/views/home_screen.dart
@@ -1,10 +1,8 @@
-import 'package:debateseason_frontend_v1/core/constants/de_gaps.dart';
 import 'package:debateseason_frontend_v1/features/home/presentation/views/home_screen_content.dart';
 import 'package:debateseason_frontend_v1/utils/amplitude_util.dart';
 import 'package:debateseason_frontend_v1/widgets/de_app_bar.dart';
 import 'package:debateseason_frontend_v1/widgets/de_scaffold.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});

--- a/lib/features/home/presentation/views/home_screen.dart
+++ b/lib/features/home/presentation/views/home_screen.dart
@@ -30,23 +30,12 @@ class _HomeScreenState extends State<HomeScreen> {
 
   DeAppBar _appbar() {
     return DeAppBar(
-      title: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          SvgPicture.asset(
-            'assets/icons/ic_logo.svg',
-            width: 24,
-            height: 24,
-          ),
-          DeGaps.h4,
-          SvgPicture.asset(
-            'assets/icons/ic_debateseason.svg',
-            width: 24,
-            height: 24,
-          ),
-        ],
-      ),
       isBack: false,
+      title: Image.asset(
+        'assets/images/img_debate_logo.png',
+        width: 84,
+        height: 24,
+      ),
     );
   }
 }

--- a/lib/features/issue/data/models/response/chat_room_res.dart
+++ b/lib/features/issue/data/models/response/chat_room_res.dart
@@ -13,6 +13,7 @@ class ChatRoomRes {
   int disagree;
   String createdAt;
   String opinion;
+  String time;
 
   ChatRoomRes({
     required this.chatRoomId,
@@ -22,6 +23,7 @@ class ChatRoomRes {
     required this.disagree,
     required this.createdAt,
     required this.opinion,
+    required this.time,
   });
 
   factory ChatRoomRes.fromJson(Map<String, dynamic> json) =>
@@ -37,6 +39,7 @@ class ChatRoomRes {
         disagree: disagree,
         createdAt: DateTime.parse(createdAt),
         opinion: _getOpinion(opinion),
+        time: time,
       );
 
   OpinionType _getOpinion(String opn) {

--- a/lib/features/issue/data/models/response/chat_room_res.g.dart
+++ b/lib/features/issue/data/models/response/chat_room_res.g.dart
@@ -14,6 +14,7 @@ ChatRoomRes _$ChatRoomResFromJson(Map<String, dynamic> json) => ChatRoomRes(
       disagree: (json['disagree'] as num).toInt(),
       createdAt: json['createdAt'] as String,
       opinion: json['opinion'] as String,
+      time: json['time'] as String,
     );
 
 Map<String, dynamic> _$ChatRoomResToJson(ChatRoomRes instance) =>
@@ -25,4 +26,5 @@ Map<String, dynamic> _$ChatRoomResToJson(ChatRoomRes instance) =>
       'disagree': instance.disagree,
       'createdAt': instance.createdAt,
       'opinion': instance.opinion,
+      'time': instance.time,
     };

--- a/lib/features/issue/domain/entities/chat_room_entity.dart
+++ b/lib/features/issue/domain/entities/chat_room_entity.dart
@@ -8,6 +8,7 @@ class ChatRoomEntity {
   int disagree;
   DateTime createdAt;
   OpinionType opinion;
+  String time;
 
   ChatRoomEntity({
     required this.chatRoomId,
@@ -17,5 +18,6 @@ class ChatRoomEntity {
     required this.disagree,
     required this.createdAt,
     required this.opinion,
+    required this.time,
   });
 }

--- a/lib/features/issue/issue_constants.dart
+++ b/lib/features/issue/issue_constants.dart
@@ -6,4 +6,5 @@ class IssueConstants {
   static const debateTopicDescription = 'AI가 생성한 본 이슈의 주요 토론 주제입니다.';
   static const noChatRoom = '채팅방이 개설되지 않았습니다';
   static const vs = 'VS';
+  static const voted = '참여 중';
 }

--- a/lib/features/issue/presentation/widgets/issue_card.dart
+++ b/lib/features/issue/presentation/widgets/issue_card.dart
@@ -118,7 +118,7 @@ class IssueCard extends StatelessWidget {
       ),
       alignment: Alignment.center,
       child: DeText(
-        '참여 중',
+        IssueConstants.voted,
         style: DeFonts.caption12SB.copyWith(color: DeColors.grey10),
       ),
     );

--- a/lib/features/issue/presentation/widgets/issue_card.dart
+++ b/lib/features/issue/presentation/widgets/issue_card.dart
@@ -74,7 +74,7 @@ class IssueCard extends StatelessWidget {
 
   Widget _issueRecent() {
     return DeText(
-      '최근', //'3분 전 대화', todo: 대화 시간 표시
+      chatroom.time,
       style: DeFonts.caption12M.copyWith(color: DeColors.brand),
     );
   }

--- a/lib/features/issuemap/presentation/views/issuemap_screen.dart
+++ b/lib/features/issuemap/presentation/views/issuemap_screen.dart
@@ -34,10 +34,9 @@ class IssuemapScreen extends GetView<IssuemapViewModel> {
   DeAppBar _appBar() {
     return DeAppBar(
       isBack: false,
-      title: Image.asset(
-        'assets/images/img_debate_logo.png',
-        width: 84,
-        height: 24,
+      title: DeText(
+        '이슈맵',
+        style: DeFonts.header20B,
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,12 +43,15 @@ class MyApp extends StatelessWidget {
       initialBinding: SplashBinding(),
       initialRoute: GetRouterName.splash,
       getPages: GetRouter.getPages,
-      theme: ThemeData.light().copyWith(
-        textTheme: ThemeData.light().textTheme.apply(
-              fontSizeFactor: 1.0,
-            ),
-      ),
-      builder: (context, child) => child!,
+      theme: ThemeData.light(),
+      builder: (context, child) {
+        final mq = MediaQuery.of(context);
+        return MediaQuery(
+          data: mq.copyWith(textScaler: TextScaler.linear(1.0)),
+          child: child!,
+        );
+
+      },
     );
   }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #154

## Work Description ✏️

- 홈 로고 크기 조정
- 이슈맵 로고 영역 삭제
- 토론방 목록에서 "n분 전 대화" 적용
- '시스템폰트 무시'가 앱바, 탭바에 적용 안 되던 문제 개선

## Screenshot 📸

<img src="https://github.com/user-attachments/assets/30d5f22d-b95b-496f-8aa7-a85ada65456d" width="240"/>
<img src="https://github.com/user-attachments/assets/d415e373-b40c-4b3e-b364-e322c96899ad" width="240"/>

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
