### PR TITLE
mod/move regidence setting

### DIFF
--- a/lib/features/profile/domain/entities/profile_entity.dart
+++ b/lib/features/profile/domain/entities/profile_entity.dart
@@ -11,8 +11,8 @@ class ProfileEntity with _$ProfileEntity {
     required String gender,
     required String ageRange,
     required CommunityEntity community,
-    @Default('') String residenceProvince,
-    @Default('') String residenceDistrict,
+    String? residenceProvince,
+    String? residenceDistrict,
     required String hometownProvince,
     required String hometownDistrict,
   }) = _ProfileEntity;

--- a/lib/features/profile/domain/entities/profile_entity.dart
+++ b/lib/features/profile/domain/entities/profile_entity.dart
@@ -11,8 +11,8 @@ class ProfileEntity with _$ProfileEntity {
     required String gender,
     required String ageRange,
     required CommunityEntity community,
-    required String residenceProvince,
-    required String residenceDistrict,
+    @Default('') String residenceProvince,
+    @Default('') String residenceDistrict,
     required String hometownProvince,
     required String hometownDistrict,
   }) = _ProfileEntity;

--- a/lib/features/profile/domain/entities/profile_entity.freezed.dart
+++ b/lib/features/profile/domain/entities/profile_entity.freezed.dart
@@ -225,8 +225,8 @@ class _$ProfileEntityImpl implements _ProfileEntity {
       required this.gender,
       required this.ageRange,
       required this.community,
-      required this.residenceProvince,
-      required this.residenceDistrict,
+      this.residenceProvince = '',
+      this.residenceDistrict = '',
       required this.hometownProvince,
       required this.hometownDistrict});
 
@@ -242,8 +242,10 @@ class _$ProfileEntityImpl implements _ProfileEntity {
   @override
   final CommunityEntity community;
   @override
+  @JsonKey()
   final String residenceProvince;
   @override
+  @JsonKey()
   final String residenceDistrict;
   @override
   final String hometownProvince;
@@ -308,8 +310,8 @@ abstract class _ProfileEntity implements ProfileEntity {
       required final String gender,
       required final String ageRange,
       required final CommunityEntity community,
-      required final String residenceProvince,
-      required final String residenceDistrict,
+      final String residenceProvince,
+      final String residenceDistrict,
       required final String hometownProvince,
       required final String hometownDistrict}) = _$ProfileEntityImpl;
 

--- a/lib/features/profile/domain/entities/profile_entity.freezed.dart
+++ b/lib/features/profile/domain/entities/profile_entity.freezed.dart
@@ -21,8 +21,8 @@ mixin _$ProfileEntity {
   String get gender => throw _privateConstructorUsedError;
   String get ageRange => throw _privateConstructorUsedError;
   CommunityEntity get community => throw _privateConstructorUsedError;
-  String get residenceProvince => throw _privateConstructorUsedError;
-  String get residenceDistrict => throw _privateConstructorUsedError;
+  String? get residenceProvince => throw _privateConstructorUsedError;
+  String? get residenceDistrict => throw _privateConstructorUsedError;
   String get hometownProvince => throw _privateConstructorUsedError;
   String get hometownDistrict => throw _privateConstructorUsedError;
 
@@ -45,8 +45,8 @@ abstract class $ProfileEntityCopyWith<$Res> {
       String gender,
       String ageRange,
       CommunityEntity community,
-      String residenceProvince,
-      String residenceDistrict,
+      String? residenceProvince,
+      String? residenceDistrict,
       String hometownProvince,
       String hometownDistrict});
 
@@ -73,8 +73,8 @@ class _$ProfileEntityCopyWithImpl<$Res, $Val extends ProfileEntity>
     Object? gender = null,
     Object? ageRange = null,
     Object? community = null,
-    Object? residenceProvince = null,
-    Object? residenceDistrict = null,
+    Object? residenceProvince = freezed,
+    Object? residenceDistrict = freezed,
     Object? hometownProvince = null,
     Object? hometownDistrict = null,
   }) {
@@ -99,14 +99,14 @@ class _$ProfileEntityCopyWithImpl<$Res, $Val extends ProfileEntity>
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
               as CommunityEntity,
-      residenceProvince: null == residenceProvince
+      residenceProvince: freezed == residenceProvince
           ? _value.residenceProvince
           : residenceProvince // ignore: cast_nullable_to_non_nullable
-              as String,
-      residenceDistrict: null == residenceDistrict
+              as String?,
+      residenceDistrict: freezed == residenceDistrict
           ? _value.residenceDistrict
           : residenceDistrict // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       hometownProvince: null == hometownProvince
           ? _value.hometownProvince
           : hometownProvince // ignore: cast_nullable_to_non_nullable
@@ -143,8 +143,8 @@ abstract class _$$ProfileEntityImplCopyWith<$Res>
       String gender,
       String ageRange,
       CommunityEntity community,
-      String residenceProvince,
-      String residenceDistrict,
+      String? residenceProvince,
+      String? residenceDistrict,
       String hometownProvince,
       String hometownDistrict});
 
@@ -170,8 +170,8 @@ class __$$ProfileEntityImplCopyWithImpl<$Res>
     Object? gender = null,
     Object? ageRange = null,
     Object? community = null,
-    Object? residenceProvince = null,
-    Object? residenceDistrict = null,
+    Object? residenceProvince = freezed,
+    Object? residenceDistrict = freezed,
     Object? hometownProvince = null,
     Object? hometownDistrict = null,
   }) {
@@ -196,14 +196,14 @@ class __$$ProfileEntityImplCopyWithImpl<$Res>
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
               as CommunityEntity,
-      residenceProvince: null == residenceProvince
+      residenceProvince: freezed == residenceProvince
           ? _value.residenceProvince
           : residenceProvince // ignore: cast_nullable_to_non_nullable
-              as String,
-      residenceDistrict: null == residenceDistrict
+              as String?,
+      residenceDistrict: freezed == residenceDistrict
           ? _value.residenceDistrict
           : residenceDistrict // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       hometownProvince: null == hometownProvince
           ? _value.hometownProvince
           : hometownProvince // ignore: cast_nullable_to_non_nullable
@@ -225,8 +225,8 @@ class _$ProfileEntityImpl implements _ProfileEntity {
       required this.gender,
       required this.ageRange,
       required this.community,
-      this.residenceProvince = '',
-      this.residenceDistrict = '',
+      this.residenceProvince,
+      this.residenceDistrict,
       required this.hometownProvince,
       required this.hometownDistrict});
 
@@ -242,11 +242,9 @@ class _$ProfileEntityImpl implements _ProfileEntity {
   @override
   final CommunityEntity community;
   @override
-  @JsonKey()
-  final String residenceProvince;
+  final String? residenceProvince;
   @override
-  @JsonKey()
-  final String residenceDistrict;
+  final String? residenceDistrict;
   @override
   final String hometownProvince;
   @override
@@ -310,8 +308,8 @@ abstract class _ProfileEntity implements ProfileEntity {
       required final String gender,
       required final String ageRange,
       required final CommunityEntity community,
-      final String residenceProvince,
-      final String residenceDistrict,
+      final String? residenceProvince,
+      final String? residenceDistrict,
       required final String hometownProvince,
       required final String hometownDistrict}) = _$ProfileEntityImpl;
 
@@ -326,9 +324,9 @@ abstract class _ProfileEntity implements ProfileEntity {
   @override
   CommunityEntity get community;
   @override
-  String get residenceProvince;
+  String? get residenceProvince;
   @override
-  String get residenceDistrict;
+  String? get residenceDistrict;
   @override
   String get hometownProvince;
   @override

--- a/lib/features/profile/presentation/view_models/profile_input_view_model.dart
+++ b/lib/features/profile/presentation/view_models/profile_input_view_model.dart
@@ -119,9 +119,9 @@ class ProfileInputViewModel extends GetxController {
         ageController.text = previousProfile.ageRange;
         _selectedAge.value = previousProfile.ageRange;
         _selectedResidenceProvince.value =
-            ProvinceType.fromCode(previousProfile.residenceProvince);
+            ProvinceType.fromCode(previousProfile.residenceProvince!);
         _selectedResidenceDistrict.value =
-            DistrictType.fromCode(previousProfile.residenceDistrict);
+            DistrictType.fromCode(previousProfile.residenceDistrict!);
         _selectedHomeTownProvince.value =
             ProvinceType.fromCode(previousProfile.hometownProvince);
         _selectedHomeTownDistrict.value =
@@ -181,12 +181,17 @@ class ProfileInputViewModel extends GetxController {
   }
 
   Future<UiState<void>> postProfile() async =>
+      // 가입페이지에서는 거주지와 출신을 선택하지 않으므로 null 값일 수 있음.
       await _profileRepository.postProfile(
         entity: _profile.value.copyWith(
           residenceProvince: _selectedResidenceProvince.value.code,
-          residenceDistrict: _selectedResidenceDistrict.value!.code,
+          residenceDistrict: _selectedResidenceDistrict.value == null
+              ? ''
+              : _selectedResidenceDistrict.value!.code,
           hometownProvince: _selectedHomeTownProvince.value.code,
-          hometownDistrict: _selectedHomeTownDistrict.value!.code,
+          hometownDistrict: _selectedHomeTownDistrict.value == null
+              ? ''
+              : _selectedHomeTownDistrict.value!.code,
         ),
       );
 

--- a/lib/features/profile/presentation/view_models/profile_input_view_model.dart
+++ b/lib/features/profile/presentation/view_models/profile_input_view_model.dart
@@ -288,8 +288,6 @@ class ProfileInputViewModel extends GetxController {
         _profile.value.gender.isNotEmpty &&
         _profile.value.ageRange.isNotEmpty &&
         _profile.value.community.id != -1 &&
-        _selectedResidenceProvince.value.code.isNotEmpty &&
-        _selectedResidenceDistrict.value != null &&
         _selectedHomeTownProvince.value.code.isNotEmpty &&
         _selectedHomeTownDistrict.value != null) {
       return true;

--- a/lib/features/profile/presentation/view_models/profile_input_view_model.dart
+++ b/lib/features/profile/presentation/view_models/profile_input_view_model.dart
@@ -293,6 +293,19 @@ class ProfileInputViewModel extends GetxController {
     }
   }
 
+  bool isValidSignUpBtn() {
+    // 가입시에는 거주지와 도시가 없음.
+    if (_profile.value.nickname.isNotEmpty &&
+        _nicknameErrorText.value.isEmpty &&
+        _profile.value.gender.isNotEmpty &&
+        _profile.value.ageRange.isNotEmpty &&
+        _profile.value.community.id != -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   void setSelectedResidenceProvince({required ProvinceType province}) {
     _selectedResidenceProvince.value = province;
     _selectedResidenceDistrict.value = null;

--- a/lib/features/profile/presentation/view_models/profile_input_view_model.dart
+++ b/lib/features/profile/presentation/view_models/profile_input_view_model.dart
@@ -15,6 +15,7 @@ import 'package:debateseason_frontend_v1/utils/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+//TODO: 거주지를 선택하지 않을 때, 거주지와 동일 체크박스 상태변경 필요함. 현재는 체크박스 상태를 관리없어서 추후 구현.
 class ProfileInputViewModel extends GetxController {
   late ProfileViewModel _profileViewModel;
   late ProfileRepository _profileRepository;
@@ -50,10 +51,15 @@ class ProfileInputViewModel extends GetxController {
   final _selectedAge = ''.obs;
   final _isModifyScreen = false.obs;
   final _isApiLoading = false.obs;
+  final residenceText = ''.obs;
+  final homeTownText = ''.obs;
   final _selectedResidenceProvince = Rx<ProvinceType>(ProvinceType.seoul);
   final _selectedResidenceDistrict = Rx<DistrictType?>(null);
   final _selectedHomeTownProvince = Rx<ProvinceType>(ProvinceType.seoul);
   final _selectedHomeTownDistrict = Rx<DistrictType?>(null);
+
+  late final VoidCallback _residenceControllerListener;
+  late final VoidCallback _homeTownControllerListener;
 
   ProfileEntity get profile => _profile.value;
 
@@ -95,7 +101,22 @@ class ProfileInputViewModel extends GetxController {
     communitySearchController = TextEditingController();
     ageController = TextEditingController();
     residenceController = TextEditingController();
+    _residenceControllerListener = () {
+      residenceText.value = residenceController.text;
+      if (residenceText.value == "") {
+        _setResidenceNoResponse();
+      }
+    };
+    residenceController.addListener(_residenceControllerListener);
     homeTownController = TextEditingController();
+    _homeTownControllerListener = () {
+      homeTownText.value = homeTownController.text;
+      if (homeTownText.value == "") {
+        _setHomeTownNoResponse();
+      }
+    };
+    homeTownController.addListener(_homeTownControllerListener);
+
     _debounceNickname?.cancel();
     _debounceCommunity?.cancel();
     _profileRepository = Get.find<ProfileRepository>();
@@ -118,18 +139,27 @@ class ProfileInputViewModel extends GetxController {
         _selectedCommunityId.value = previousProfile.community.id;
         ageController.text = previousProfile.ageRange;
         _selectedAge.value = previousProfile.ageRange;
-        _selectedResidenceProvince.value =
-            ProvinceType.fromCode(previousProfile.residenceProvince!);
-        _selectedResidenceDistrict.value =
-            DistrictType.fromCode(previousProfile.residenceDistrict!);
-        _selectedHomeTownProvince.value =
-            ProvinceType.fromCode(previousProfile.hometownProvince);
-        _selectedHomeTownDistrict.value =
-            DistrictType.fromCode(previousProfile.hometownDistrict);
-        residenceController.text =
-            '${_selectedResidenceProvince.value.name} ${_selectedResidenceDistrict.value?.name}';
-        homeTownController.text =
-            '${_selectedHomeTownProvince.value.name} ${_selectedHomeTownDistrict.value?.name}';
+
+        if (previousProfile.residenceDistrict != '') {
+          _selectedResidenceProvince.value =
+              ProvinceType.fromCode(previousProfile.residenceProvince!);
+          _selectedResidenceDistrict.value =
+              DistrictType.fromCode(previousProfile.residenceDistrict!);
+          residenceController.text =
+              '${_selectedResidenceProvince.value.name} ${_selectedResidenceDistrict.value?.name}';
+        } else {
+          residenceController.text = '';
+        }
+        if (previousProfile.hometownDistrict != '') {
+          _selectedHomeTownProvince.value =
+              ProvinceType.fromCode(previousProfile.hometownProvince);
+          _selectedHomeTownDistrict.value =
+              DistrictType.fromCode(previousProfile.hometownDistrict);
+          homeTownController.text =
+              '${_selectedHomeTownProvince.value.name} ${_selectedHomeTownDistrict.value?.name}';
+        } else {
+          homeTownController.text = '';
+        }
         _isModifyScreen.value = true;
         _profile.refresh();
       });
@@ -143,7 +173,9 @@ class ProfileInputViewModel extends GetxController {
     communityController.dispose();
     communitySearchController.dispose();
     ageController.dispose();
+    residenceController.removeListener(_residenceControllerListener);
     residenceController.dispose();
+    homeTownController.removeListener(_homeTownControllerListener);
     homeTownController.dispose();
 
     super.dispose();
@@ -184,18 +216,15 @@ class ProfileInputViewModel extends GetxController {
       // 가입페이지에서는 거주지와 출신을 선택하지 않으므로 null 값일 수 있음.
       await _profileRepository.postProfile(
         entity: _profile.value.copyWith(
-          residenceProvince: _selectedResidenceProvince.value.code,
-          residenceDistrict: _selectedResidenceDistrict.value == null
-              ? ''
-              : _selectedResidenceDistrict.value!.code,
-          hometownProvince: _selectedHomeTownProvince.value.code,
-          hometownDistrict: _selectedHomeTownDistrict.value == null
-              ? ''
-              : _selectedHomeTownDistrict.value!.code,
+          residenceProvince: null,
+          residenceDistrict: null,
+          hometownProvince: '',
+          hometownDistrict: '',
         ),
       );
 
   Future<UiState<void>> patchProfile() async {
+    // profile 수정 페이지
     _profileViewModel.updateProfile(updatedProfile: _profile.value);
 
     return await _profileRepository.patchProfile(entity: _profile.value);
@@ -288,8 +317,12 @@ class ProfileInputViewModel extends GetxController {
         _profile.value.gender.isNotEmpty &&
         _profile.value.ageRange.isNotEmpty &&
         _profile.value.community.id != -1 &&
-        _selectedHomeTownProvince.value.code.isNotEmpty &&
-        _selectedHomeTownDistrict.value != null) {
+        (residenceText.value == '' ||
+            (_selectedResidenceProvince.value.code.isNotEmpty &&
+                _selectedResidenceDistrict.value != null)) &&
+        (homeTownText.value == '' ||
+            (_selectedHomeTownProvince.value.code.isNotEmpty &&
+                _selectedHomeTownDistrict.value != null))) {
       return true;
     } else {
       return false;
@@ -337,7 +370,26 @@ class ProfileInputViewModel extends GetxController {
     );
   }
 
+  void _setResidenceNoResponse() {
+    _profile.value = _profile.value.copyWith(
+      residenceProvince: '',
+      residenceDistrict: '',
+    );
+  }
+
+  void _setHomeTownNoResponse() {
+    _profile.value = _profile.value.copyWith(
+      hometownProvince: '',
+      hometownDistrict: '',
+    );
+  }
+
   void checkSameToResidence() {
+    if (residenceText.value == '') {
+      homeTownController.text = '';
+      return;
+    }
+
     if (_selectedResidenceDistrict.value != null) {
       _selectedHomeTownProvince.value = _selectedResidenceProvince.value;
       _selectedHomeTownDistrict.value = _selectedResidenceDistrict.value;

--- a/lib/features/profile/presentation/views/profile_input_screen.dart
+++ b/lib/features/profile/presentation/views/profile_input_screen.dart
@@ -21,7 +21,8 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
     return Obx(() {
       return DeScaffold(
         appBar: _appBar(isModifyScreen: controller.isModifyScreen),
-        body: _body(context: context),
+        body:
+            _body(isModifyScreen: controller.isModifyScreen, context: context),
       );
     });
   }
@@ -38,7 +39,7 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
     );
   }
 
-  Widget _body({required BuildContext context}) {
+  Widget _body({required bool isModifyScreen, required BuildContext context}) {
     Obx(() {
       if (controller.isApiLoading) {
         return DeProgressIndicator();
@@ -62,10 +63,12 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
                 _widgetGender(),
                 DeGaps.v32,
                 _widgetAge(),
-                DeGaps.v32,
-                _widgetResidence(context: context),
-                DeGaps.v32,
-                _widgetHomeTown(context: context),
+                if (isModifyScreen) ...[
+                  DeGaps.v32,
+                  _widgetResidence(context: context),
+                  DeGaps.v32,
+                  _widgetHomeTown(context: context),
+                ],
                 DeGaps.v40,
                 _widgetBottomButton(),
                 DeGaps.v20,
@@ -427,38 +430,40 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
   Widget _widgetBottomButton() {
     return Obx(() {
       return DeButtonLarge(
-        controller.isModifyScreen
-            ? ProfileConstants.PROFILE_MODIFY_BTN_TEXT
-            : ProfileConstants.PROFILE_NEXT_BTN_TEXT,
-        onPressed: controller.isValidStartBtn()
-            ? controller.isModifyScreen
-                ? () => controller.patchProfile().then((result) {
-                      result.when(loading: () {
-                        controller.setApiLoading(isApiLoading: true);
-                      }, success: (_) {
-                        controller.setApiLoading(isApiLoading: false);
-                        Get.back();
-                      }, failure: (msg) {
-                        controller.setApiLoading(isApiLoading: false);
-                        deSnackBar(msg);
-                      });
-                    })
-                : () => controller.postProfile().then((result) {
-                      result.when(loading: () {
-                        controller.setApiLoading(isApiLoading: true);
-                      }, success: (_) {
-                        controller.setApiLoading(isApiLoading: false);
-                        Get.offAllNamed(GetRouterName.profileImage, arguments: {
-                          'is_modify_screen': controller.isModifyScreen,
+          controller.isModifyScreen
+              ? ProfileConstants.PROFILE_MODIFY_BTN_TEXT
+              : ProfileConstants.PROFILE_NEXT_BTN_TEXT,
+          onPressed: controller.isValidStartBtn()
+              ? controller.isModifyScreen
+                  ? () => controller.patchProfile().then((result) {
+                        result.when(loading: () {
+                          controller.setApiLoading(isApiLoading: true);
+                        }, success: (_) {
+                          controller.setApiLoading(isApiLoading: false);
+                          Get.back();
+                        }, failure: (msg) {
+                          controller.setApiLoading(isApiLoading: false);
+                          deSnackBar(msg);
                         });
-                      }, failure: (msg) {
-                        controller.setApiLoading(isApiLoading: false);
-                        deSnackBar(msg);
-                      });
-                    })
-            : () => {},
-        enable: controller.isValidStartBtn(),
-      );
+                      })
+                  : () => controller.postProfile().then((result) {
+                        result.when(loading: () {
+                          controller.setApiLoading(isApiLoading: true);
+                        }, success: (_) {
+                          controller.setApiLoading(isApiLoading: false);
+                          Get.offAllNamed(GetRouterName.profileImage,
+                              arguments: {
+                                'is_modify_screen': controller.isModifyScreen,
+                              });
+                        }, failure: (msg) {
+                          controller.setApiLoading(isApiLoading: false);
+                          deSnackBar(msg);
+                        });
+                      })
+              : () => {},
+          enable: controller.isModifyScreen
+              ? controller.isValidStartBtn()
+              : controller.isValidSignUpBtn());
     });
   }
 }

--- a/lib/features/profile/presentation/views/profile_input_screen.dart
+++ b/lib/features/profile/presentation/views/profile_input_screen.dart
@@ -433,7 +433,9 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
           controller.isModifyScreen
               ? ProfileConstants.PROFILE_MODIFY_BTN_TEXT
               : ProfileConstants.PROFILE_NEXT_BTN_TEXT,
-          onPressed: controller.isValidStartBtn()
+          onPressed: (controller.isModifyScreen
+                  ? controller.isValidStartBtn()
+                  : controller.isValidSignUpBtn())
               ? controller.isModifyScreen
                   ? () => controller.patchProfile().then((result) {
                         result.when(loading: () {

--- a/lib/features/profile/presentation/views/profile_input_screen.dart
+++ b/lib/features/profile/presentation/views/profile_input_screen.dart
@@ -312,10 +312,6 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
               ProfileConstants.PROFILE_RESIDENCE,
               style: DeFonts.body14Sb,
             ),
-            DeText(
-              ProfileConstants.PROFILE_ESSENTIAL_STAR,
-              style: DeFonts.body14Sb.copyWith(color: DeColors.brand),
-            )
           ],
         ),
         DeGaps.v4,

--- a/lib/features/profile/presentation/views/profile_input_screen.dart
+++ b/lib/features/profile/presentation/views/profile_input_screen.dart
@@ -334,13 +334,16 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
               );
             }
           },
-          child: DeTextField(
-            style: DeFonts.body16M,
-            hintText: ProfileConstants.PROFILE_RESIDENCE_HINT_TEXT,
-            controller: controller.residenceController,
-            enabled: false,
-            isCleanIcon: true,
-          ),
+          child: Obx(() {
+            // 선택한 사항이 없을 경우, isCleanItem 이 사라짐.
+            return DeTextField(
+              style: DeFonts.body16M,
+              hintText: ProfileConstants.PROFILE_RESIDENCE_HINT_TEXT,
+              controller: controller.residenceController,
+              enabled: false,
+              isCleanIcon: controller.residenceText.value != "",
+            );
+          }),
         ),
       ],
     );
@@ -378,12 +381,18 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
               );
             }
           },
-          child: DeTextField(
-            style: DeFonts.body16M,
-            hintText: ProfileConstants.PROFILE_HOME_TOWN_HINT_TEXT,
-            controller: controller.homeTownController,
-            enabled: false,
-            isCleanIcon: true,
+          child: Obx(
+            () {
+              // 선택한 사항이 없을 경우, isCleanItem 이 사라짐.
+
+              return DeTextField(
+                style: DeFonts.body16M,
+                hintText: ProfileConstants.PROFILE_HOME_TOWN_HINT_TEXT,
+                controller: controller.homeTownController,
+                enabled: false,
+                isCleanIcon: controller.homeTownText.value != "",
+              );
+            },
           ),
         ),
         DeGaps.v12,

--- a/lib/features/profile/presentation/views/profile_input_screen.dart
+++ b/lib/features/profile/presentation/views/profile_input_screen.dart
@@ -339,7 +339,7 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
             hintText: ProfileConstants.PROFILE_RESIDENCE_HINT_TEXT,
             controller: controller.residenceController,
             enabled: false,
-            isCleanIcon: false,
+            isCleanIcon: true,
           ),
         ),
       ],
@@ -355,10 +355,6 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
             DeText(
               ProfileConstants.PROFILE_HOME_TOWN,
               style: DeFonts.body14Sb,
-            ),
-            DeText(
-              ProfileConstants.PROFILE_ESSENTIAL_STAR,
-              style: DeFonts.body14Sb.copyWith(color: DeColors.brand),
             )
           ],
         ),
@@ -387,7 +383,7 @@ class ProfileInputScreen extends GetView<ProfileInputViewModel> {
             hintText: ProfileConstants.PROFILE_HOME_TOWN_HINT_TEXT,
             controller: controller.homeTownController,
             enabled: false,
-            isCleanIcon: false,
+            isCleanIcon: true,
           ),
         ),
         DeGaps.v12,

--- a/lib/widgets/de_text_field.dart
+++ b/lib/widgets/de_text_field.dart
@@ -2,7 +2,6 @@ import 'package:debateseason_frontend_v1/core/constants/de_colors.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_dimensions.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_fonts.dart';
 import 'package:debateseason_frontend_v1/core/constants/de_icons.dart';
-import 'package:debateseason_frontend_v1/widgets/de_gesture_detector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -59,67 +58,86 @@ class DeTextField extends StatelessWidget {
       data: MediaQuery.of(context).copyWith(
         textScaler: const TextScaler.linear(1),
       ),
-      child: TextField(
-        controller: controller,
-        focusNode: focusNode,
-        decoration: decoration ??
-            InputDecoration(
-              border: InputBorder.none,
-              hintStyle: style?.copyWith(color: DeColors.grey50),
-              hintText: hintText ?? '내용을 입력해 주세요.',
-              contentPadding: DeDimensions.all12,
-              isDense: true,
-              counterText: "",
-              filled: true,
-              fillColor: fillColor ?? DeColors.grey80,
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
+      child: Stack(
+        children: [
+          TextField(
+            controller: controller,
+            focusNode: focusNode,
+            decoration: decoration ??
+                InputDecoration(
+                  border: InputBorder.none,
+                  hintStyle: style?.copyWith(color: DeColors.grey50),
+                  hintText: hintText ?? '내용을 입력해 주세요.',
+                  contentPadding: DeDimensions.all12,
+                  isDense: true,
+                  counterText: "",
+                  filled: true,
+                  fillColor: fillColor ?? DeColors.grey80,
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide.none,
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(color: DeColors.brand, width: 1),
+                  ),
+                  disabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide.none,
+                  ),
+                  // suffixIcon: isCleanIcon
+                  //     ? (controller.text.isNotEmpty
+                  //         ? DeGestureDetector(
+                  //             onTap: () {
+                  //               controller.clear();
+                  //             },
+                  //             child: Padding(
+                  //               padding: DeDimensions.all10,
+                  //               child: SvgPicture.asset(DeIcons.icXGrey50),
+                  //             ),
+                  //           )
+                  //         : null)
+                  //     : SizedBox.shrink(),
+                ),
+            keyboardType: keyboardType,
+            textInputAction: textInputAction,
+            autofocus: autofocus,
+            maxLines: maxLines,
+            minLines: minLines,
+            expands: expands,
+            maxLength: maxLength,
+            // 색상 변경 여부 확인
+            cursorColor: DeColors.grey10,
+            style: style ?? DeFonts.body14R,
+            textAlign: textAlign ?? TextAlign.start,
+            onChanged: (value) {
+              if (onChanged != null) {
+                onChanged!(value);
+              }
+            },
+            onSubmitted: (value) {
+              if (onSubmitted != null) {
+                onSubmitted!(value);
+              }
+            },
+            inputFormatters: inputFormatters,
+
+            enabled: enabled,
+            textAlignVertical: textAlignVertical,
+          ),
+          if (isCleanIcon)
+            Positioned(
+              right: 4,
+              top: 0,
+              bottom: 0,
+              child: GestureDetector(
+                onTap: () => controller.clear(),
+                child: Padding(
+                    padding: DeDimensions.all10,
+                    child: SvgPicture.asset(DeIcons.icXGrey50)),
               ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: DeColors.brand, width: 1),
-              ),
-              disabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              suffixIcon: isCleanIcon
-                  ? (controller.text.isNotEmpty
-                      ? DeGestureDetector(
-                          onTap: () => controller.clear(),
-                          child: Padding(
-                            padding: DeDimensions.all10,
-                            child: SvgPicture.asset(DeIcons.icXGrey50),
-                          ),
-                        )
-                      : null)
-                  : SizedBox.shrink(),
-            ),
-        keyboardType: keyboardType,
-        textInputAction: textInputAction,
-        autofocus: autofocus,
-        maxLines: maxLines,
-        minLines: minLines,
-        expands: expands,
-        maxLength: maxLength,
-        // 색상 변경 여부 확인
-        cursorColor: DeColors.grey10,
-        style: style ?? DeFonts.body14R,
-        textAlign: textAlign ?? TextAlign.start,
-        onChanged: (value) {
-          if (onChanged != null) {
-            onChanged!(value);
-          }
-        },
-        onSubmitted: (value) {
-          if (onSubmitted != null) {
-            onSubmitted!(value);
-          }
-        },
-        inputFormatters: inputFormatters,
-        enabled: enabled,
-        textAlignVertical: textAlignVertical,
+            )
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Related issue 🛠

- closed #160

## Work Description ✏️

- 가입 화면에서 거주지, 출신지 미선택으로 변경.
- 가입 이후, 프로파일 화면에서 거주지, 출신지 선택할 수 있도록 변경.
**Button 위젯 수정함.** (Stack 으로 Clear Icon 을 위로 쌓음.) <- 영향성 검토 필요함.

<img width="347" height="122" alt="image" src="https://github.com/user-attachments/assets/04a95501-c322-43d0-93cd-e342a6aa623d" />

- 기존 Clear Button 동작 안함.
   - enable 이 false 이면 사용자가 수정 불가함. 하지만 clear button 도 동작하지 않음.
   - enable 이 true 이면 clear button 동작함. 하지만 사용자가 수정가능함.
   - **Button 위젯 수정함.** (Stack 으로 Clear Icon 을 위로 쌓음.)

<img width="338" height="111" alt="image" src="https://github.com/user-attachments/assets/5a450121-8cf3-449d-bfe8-f6f5b4cb30ce" />

- 거주지 미선택시에도 버튼 Enable 될 수 있도록 변경.
- Clear 버튼 눌렀을 때, Clear 버튼은 사라지도록 추가적인 상태관리 변수 추가함.

## Uncompleted Tasks 😅

<img width="336" height="264" alt="image" src="https://github.com/user-attachments/assets/c6063204-745d-4dca-b5e8-b4a06eff84c2" />

- 거주지 동일 체크박스 여부에 따라 거주지를 미입력시, 출신지도 미입력으로 변경되어야함.
- 일단 그대로 나둠. 

## To Reviewers 📢
